### PR TITLE
Parse message attributes until end of message, not end of buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! ```
 
 #![warn(missing_docs)]
-#![warn(missing_doc_code_examples)]
+#![warn(rustdoc::missing_doc_code_examples)]
 #![allow(clippy::module_inception)]
 
 #[macro_use]

--- a/src/message/decode.rs
+++ b/src/message/decode.rs
@@ -18,12 +18,10 @@ impl StunMessage {
         bytes: &[u8],
         integrity_password: Option<&str>,
     ) -> Result<Self, MessageDecodeError> {
-        let data_len = bytes.len();
         let mut cursor = Cursor::new(bytes);
 
         // Decode header
         let header = StunHeader::decode(&mut cursor)?;
-
         // Decode attributes
         let mut attributes = Vec::new();
 
@@ -33,7 +31,8 @@ impl StunMessage {
         let mut username = None;
         let mut realm = None;
 
-        while cursor.position() < data_len as u64 {
+        // Message length does not include the 20-byte header.
+        while cursor.position() < 20 + header.message_len as u64 {
             let decoded = StunAttribute::decode(&mut cursor, header.transaction_id);
 
             match decoded {


### PR DESCRIPTION
Hi, and thanks for this very nicely designed lib :)
When providing the buffer to decode the message, currently one needs to know beforehand the size of the message received but that is impossible. This PR fixes that by parsing only the Message Length instead.